### PR TITLE
Avoid crash when null form is passed

### DIFF
--- a/CRM/Advimportformprocessor/Advimport/Formprocessor.php
+++ b/CRM/Advimportformprocessor/Advimport/Formprocessor.php
@@ -8,6 +8,9 @@ class CRM_Advimportformprocessor_Advimport_Formprocessor extends CRM_Advimport_H
    * Available fields.
    */
   function getMapping(&$form) {
+    if (is_null($form)) {
+      return [];
+    }
     $map = [];
 
     // QuickForm weirdness: this gets called before setDefaults


### PR DESCRIPTION
With the latest versions of ``form-processor`` and ``advimport``, the import process seems to crash sometimes. This change prevents that.

My suspicion is, that it the ``getMapping`` function is now called with a ``null`` object first, and cutting this call short doesn't seem to do any harm.
