### PR TITLE
Fix for multiple form processors

### DIFF
--- a/CRM/Advimportformprocessor/Advimport/Formprocessor.php
+++ b/CRM/Advimportformprocessor/Advimport/Formprocessor.php
@@ -27,7 +27,7 @@ class CRM_Advimportformprocessor_Advimport_Formprocessor extends CRM_Advimport_H
 
       $fields = civicrm_api3('FormProcessorInput', 'get', [
         'sequential' => 1,
-        'form_processor_instance_id' => $formProcessorInstanceId,
+        'form_processor_id' => $formProcessorInstanceId,
       ])['values'];
 
       foreach ($fields as $val) {
@@ -121,7 +121,7 @@ class CRM_Advimportformprocessor_Advimport_Formprocessor extends CRM_Advimport_H
     // Check for mandatory fields
     $fields = civicrm_api3('FormProcessorInput', 'get', [
       'sequential' => 1,
-      'form_processor_instance_id' => $formProcessorInstanceId,
+      'form_processor_id' => $formProcessorInstanceId,
     ])['values'];
 
     foreach ($fields as $key => $val) {


### PR DESCRIPTION
When you have more than one form processor and you want to do an import with the form processors it will list the fields of all the form processors and not only the selected one. This PR fixes that