### PR TITLE
Add name to to Advimport Forms Processor

### DIFF
--- a/advimportformprocessor.php
+++ b/advimportformprocessor.php
@@ -11,6 +11,7 @@ function advimportformprocessor_civicrm_advimport_helpers(&$helpers) {
   $helpers[] = [
     'class' => 'CRM_Advimportformprocessor_Advimport_Formprocessor',
     'label' => E::ts('Form Processor'),
+    'name'  => 'advimport_formprocessor',
   ];
 }
 


### PR DESCRIPTION
Hi @MegaphoneJon, the name of the helper function is needed for the permission scheme of AdvImport. See the `advimport_civicrm_permission` hook. I have added the name to make it working.